### PR TITLE
Format docstrings for correct display in sphinx-generated bootstrap pages

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -226,6 +226,8 @@ autodoc_default_options = {
 
 autodoc_member_order = 'groupwise'
 
+autodoc_mock_imports = ["Rhino", "Grasshopper", "ladybug_dotnet",
+                        "scriptcontext", "System"]
 
 def setup(app):
     """Run custom code with access to the Sphinx application object

--- a/ladybug_rhino/bakeobjects.py
+++ b/ladybug_rhino/bakeobjects.py
@@ -17,11 +17,14 @@ def add_legend_to_scene(legend, layer_name=None):
             text. If None, text will be added to the current layer.
 
     Returns:
-        A list of IDs that point to the objects in the Rhino scene.
-        They are in the following order:
-            legend_mesh: A colored mesh for the legend.
-            legend_title: A text object for the legend title.
-            legend_text: Text objects for the rest of the legend text.
+        A list of IDs that point to the objects in the Rhino scene in the following
+        order:
+
+        -   legend_mesh -- A colored mesh for the legend.
+
+        -   legend_title -- A text object for the legend title.
+
+        -   legend_text -- Text objects for the rest of the legend text.
     """
     _height = legend.legend_parameters.text_height
     _font = legend.legend_parameters.font

--- a/ladybug_rhino/fromobjects.py
+++ b/ladybug_rhino/fromobjects.py
@@ -15,10 +15,13 @@ def legend_objects(legend):
         legend: A Ladybug Legend object to be converted to Rhino geometry.
 
     Returns:
-        A list of Rhino geometries in the following order:
-            legend_mesh: A colored mesh for the legend.
-            legend_title: A bake-able text object for the legend title.
-            legend_text: Bake-able text objects for the rest of the legend text.
+        A list of Rhino geometries in the following order.
+
+        -   legend_mesh -- A colored mesh for the legend.
+
+        -   legend_title -- A bake-able text object for the legend title.
+
+        -   legend_text -- Bake-able text objects for the rest of the legend text.
     """
     _height = legend.legend_parameters.text_height
     _font = legend.legend_parameters.font

--- a/ladybug_rhino/grasshopper.py
+++ b/ladybug_rhino/grasshopper.py
@@ -94,7 +94,7 @@ def data_tree_to_list(input):
         input: A Grasshopper DataTree.
 
     Returns:
-        listData: A list of namedtuples (path, dataList)
+        listData -- A list of namedtuples (path, dataList)
     """
     all_data = list(range(len(input.Paths)))
     Pattern = namedtuple('Pattern', 'path list')
@@ -137,8 +137,11 @@ def flatten_data_tree(input):
         input: A Grasshopper DataTree.
 
     Returns:
-        all_data: All data in DataTree as a flattened list.
-        pattern: A dictonary of patterns as namedtuple(path, index of last item
+        A tuple with two elements
+
+        -   all_data -- All data in DataTree as a flattened list.
+
+        -   pattern -- A dictonary of patterns as namedtuple(path, index of last item
             on this path, path Count). Pattern is useful to unflatten the list
             back to a DataTree.
     """
@@ -170,7 +173,7 @@ def unflatten_to_data_tree(all_data, pattern):
             Pattern = namedtuple('Pattern', 'path index count')
 
     Returns:
-        data_tree: A Grasshopper DataTree.
+        data_tree -- A Grasshopper DataTree.
     """
     data_tree = DataTree[Object]()
     for branch in range(len(pattern)):

--- a/ladybug_rhino/intersect.py
+++ b/ladybug_rhino/intersect.py
@@ -18,17 +18,17 @@ from .config import tolerance
 
 def intersect_solids_parallel(solids, bound_boxes):
     """Intersect the co-planar faces of an array of solids using parallel processing.
-    
+
     Args:
         original_solids: An array of closed Rhino breps (polysurfaces) that do
             not have perfectly matching surfaces between adjacent Faces.
         bound_boxes: An array of Rhino bounding boxes that parellels the input
             solids and will be used to check whether two Breps have any potential
             for intersection before the actual intersection is performed.
-     
-     Returns:
-         int_solids: The input array of solids, which have all been intersected
-            with one another.
+
+    Returns:
+        int_solids -- The input array of solids, which have all been intersected
+        with one another.
     """
     int_solids = solids[:]  # copy the input list to avoid editing it
 
@@ -56,17 +56,17 @@ def intersect_solids_parallel(solids, bound_boxes):
 
 def intersect_solids(solids, bound_boxes):
     """Intersect the co-planar faces of an array of solids.
-    
+
     Args:
         original_solids: An array of closed Rhino breps (polysurfaces) that do
             not have perfectly matching surfaces between adjacent Faces.
         bound_boxes: An array of Rhino bounding boxes that parellels the input
             solids and will be used to check whether two Breps have any potential
             for intersection before the actual intersection is performed.
-     
-     Returns:
-         int_solids: The input array of solids, which have all been intersected
-            with one another.
+
+    Returns:
+        int_solids -- The input array of solids, which have all been intersected
+        with one another.
     """
     int_solids = solids[:]  # copy the input list to avoid editing it
 
@@ -91,15 +91,18 @@ def intersect_solids(solids, bound_boxes):
 
 def intersect_solid(solid, other_solid):
     """Intersect the co-planar faces of one solid Brep using another.
-    
+
     Args:
         solid: The solid Brep which will be split with intersections.
         other_solid: The other Brep, which will be used to split.
         tolerance: Distance within which two points are considered to be co-located.
-    
+
     Returns:
-        solid: The input solid, which has been split.
-        intersection_exists: Boolean to note whether an intersection was found
+        A tuple with two elements
+
+        -   solid -- The input solid, which has been split.
+
+        -   intersection_exists -- Boolean to note whether an intersection was found
             between the solid and the other_solid. If False, there's no need to
             split the other_solid with the input solid.
     """
@@ -115,7 +118,7 @@ def intersect_solid(solid, other_solid):
             if face.IsSurface:  # untrimmed surface
                 intersect_lines = rg.Intersect.Intersection.BrepSurface(
                     other_solid, face.DuplicateSurface(), tolerance)[1]
-            else:  # trimmed surfaces 
+            else:  # trimmed surfaces
                 edges_idx = face.AdjacentEdges()
                 edges = []
                 for ix in edges_idx:
@@ -189,8 +192,8 @@ def split_solid_to_floors(building_solid, floor_heights):
             will be used to generate planes that subdivide the building solid.
 
     Returns:
-        floor_breps: A list of planar, horizontal breps representing the floors
-            of the building.
+        floor_breps -- A list of planar, horizontal breps representing the floors
+        of the building.
     """
     # get the floor brep at each of the floor heights.
     floor_breps = []

--- a/ladybug_rhino/text.py
+++ b/ladybug_rhino/text.py
@@ -54,14 +54,13 @@ class TextGoo(gh.Kernel.Types.GH_GeometricGoo[rh.Display.Text3d],
     The code for this entire class was taken from David Rutten and Giulio Piacentino's
     script described here:
     https://discourse.mcneel.com/t/creating-text-objects-and-outputting-them-as-normal-rhino-geometry/47834/7
+
+    Args:
+        text: A Rhino Text3d object.
     """
 
     def __init__(self, text):
-        """Initialize Bake-able text.
-
-        Args:
-            text: A Rhino Text3d object.
-        """
+        """Initialize Bake-able text."""
         self.m_value = text
 
     @staticmethod


### PR DESCRIPTION
Hi @chriswmackey,

I did some research and found a way to ignore libraries that can not be found in the build process. You can use the `autodoc_mock_imports` config value in the config.py file with the list of libraries you want sphinx to ignore (or rather create mock imports of). For future reference, only this has to include top-level modules, I noticed submodules will be ignored.

I added also for your review the changes to the docstrings, these were minimal and pretty straightforward.
