### PR TITLE
feat(planarize) Improve planarization of closed solids

### DIFF
--- a/ladybug_rhino/colorize.py
+++ b/ladybug_rhino/colorize.py
@@ -1,0 +1,72 @@
+"""Classes for colorized versions of various Rhino objects like points."""
+try:
+    import Rhino as rh
+    import System.Guid as guid
+except ImportError as e:
+    raise ImportError(
+        "Failed to import Rhino.\n{}".format(e))
+try:
+    import Grasshopper as gh
+except ImportError:
+    print('Failed to import Grasshopper.\n'
+          'Only functions for adding text to Rhino will be availabe.')
+try:
+    from ladybug_dotnet.color import black
+except ImportError as e:
+    black = None
+    print("Failed to import ladybug_dotnet.\n{}".format(e))
+
+
+class ColoredPoint(gh.Kernel.Types.GH_Point, gh.Kernel.IGH_BakeAwareData,
+                   gh.Kernel.IGH_PreviewData):
+    """A Point object with a set-able color property to change its color in Grasshopper.
+
+    Args:
+        point: A Rhino Point3d object.
+    """
+
+    def __init__(self, point):
+        """Initialize ColoredPoint."""
+        self.point = point
+        self.color = black()
+
+    def DuplicateGeometry(self):
+        point = rh.Geometry.Point3d(self.point.X, self.point.Y, self.point.Z)
+        new_pt = ColoredPoint(point)
+        new_pt.color = self.color
+        return new_pt
+
+    def get_TypeName(self):
+        return "Colored Point"
+
+    def get_TypeDescription(self):
+        return "Colored Point"
+
+    def ToString(self):
+        return '{' + '{}, {}, {}'.format(self.point.X, self.point.Y, self.point.Z) + '}'
+
+    def Transform(self, xform):
+        point = rh.Geometry.Point3d(self.point.X, self.point.Y, self.point.Z)
+        point.Transform(xform)
+        new_pt = ColoredPoint(point)
+        new_pt.color = self.color
+        return new_pt
+
+    def Morph(self, xmorph):
+        return self.DuplicateGeometry()
+
+    def DrawViewportWires(self, args):
+        args.Pipeline.DrawPoint(self.point, rh.Display.PointStyle.RoundSimple, 5, self.color)
+
+    def DrawViewportMeshes(self, args):
+        # Do not draw in meshing layer.
+        pass
+
+    def BakeGeometry(self, doc, att, id):
+        id = guid.Empty
+        if att is None:
+            att = doc.CreateDefaultAttributes()
+        att.ColorSource = rh.DocObjects.ObjectColorSource.ColorFromObject
+        att.ObjectColor = self.color
+        id = doc.Objects.AddPoint(self.point, att)
+        return True, id

--- a/ladybug_rhino/planarize.py
+++ b/ladybug_rhino/planarize.py
@@ -40,7 +40,7 @@ def planar_face_curved_edge_vertices(b_face, count, meshing_parameters):
     loop_verts = []
     try:
         loop_pcrvs = [loop_pcrv.SegmentCurve(i)
-                      for i in range(loop_pcrv.SegmentCount)]
+                      for i in xrange(loop_pcrv.SegmentCount)]
     except Exception:
         try:
             loop_pcrvs = [loop_pcrv[0]]
@@ -54,12 +54,12 @@ def planar_face_curved_edge_vertices(b_face, count, meshing_parameters):
             seg_mesh = rg.Mesh.CreateFromSurface(
                 rg.Surface.CreateExtrusion(seg, f_norm),
                 meshing_parameters)
-            for i in range(seg_mesh.Vertices.Count / 2 - 1):
+            for i in xrange(seg_mesh.Vertices.Count / 2 - 1):
                 loop_verts.append(_point3d(seg_mesh.Vertices[i]))
     return loop_verts
 
 
-def curved_geometry_faces(b_face, meshing_parameters):
+def curved_surface_faces(b_face, meshing_parameters):
     """Extract Face3D objects from a curved brep face.
 
     Args:
@@ -71,35 +71,98 @@ def curved_geometry_faces(b_face, meshing_parameters):
         A list of ladybug Face3D objects that together approximate the input
         curved surface.
     """
-    faces = []
     if b_face.OrientationIsReversed:
         b_face.Reverse(0, True)
     face_brep = b_face.DuplicateFace(True)
     meshed_brep = rg.Mesh.CreateFromBrep(face_brep, meshing_parameters)[0]
-    for m_face in meshed_brep.Faces:
-        if m_face.IsQuad:
-            lb_face = Face3D(
-                tuple(_point3d(meshed_brep.Vertices[i]) for i in
-                      (m_face.A, m_face.B, m_face.C, m_face.D)))
-            if lb_face.check_planar(tolerance, False):
-                faces.append(lb_face)
-            else:
-                lb_face_1 = Face3D(
-                    tuple(_point3d(meshed_brep.Vertices[i]) for i in
-                          (m_face.A, m_face.B, m_face.C)))
-                lb_face_2 = Face3D(
-                    tuple(_point3d(meshed_brep.Vertices[i]) for i in
-                          (m_face.C, m_face.D, m_face.A)))
-                faces.extend([lb_face_1, lb_face_2])
+    return mesh_faces_to_face3d(meshed_brep)
+
+
+"""____________SOLID BREPS TO PLANAR____________"""
+
+
+def curved_solid_faces(brep, meshing_parameters):
+    """Extract Face3D objects from a curved solid brep.
+
+    This methods ensures that the resulting Face3Ds form a closed solid by
+    meshing the solid Brep alltogether.
+
+    Args:
+        brep: A curved solid brep.
+        meshing_parameters: Rhino Meshing Parameters to describe how
+            curved edge should be convereted into planar elements.
+
+    Returns:
+        A list of ladybug Face3D objects that together approximate the input brep.
+    """
+    # mesh the geometry as a solid
+    meshed_geo = rg.Mesh.CreateFromBrep(brep, meshing_parameters)
+
+    # evaluate each mesh face to see what larger brep face it is a part of
+    faces = []
+    for mesh, b_face in zip(meshed_geo, brep.Faces):
+        if b_face.IsPlanar(tolerance):  # only take the naked vertices of planar faces
+            naked_edges = mesh.GetNakedEdges()
+            all_verts = []
+            for loop_pline in naked_edges:  # each loop_pline is a boundary/hole
+                all_verts.append([_point3d(loop_pline.Item[i])
+                                  for i in xrange(loop_pline.Count - 1)])
+            if len(all_verts) == 1:  # No holes in the shape
+                faces.append(Face3D(all_verts[0]))
+            else:  # There's at least one hole in the shape
+                faces.append(
+                    Face3D(boundary=all_verts[0], holes=all_verts[1:]))
         else:
-            lb_face = Face3D(
-                tuple(_point3d(meshed_brep.Vertices[i]) for i in
-                      (m_face.A, m_face.B, m_face.C)))
-            faces.append(lb_face)
+            faces.extend(mesh_faces_to_face3d(mesh))
     return faces
 
 
 """________________EXTRA HELPER FUNCTIONS________________"""
+
+
+def has_curved_face(brep):
+    """Test if a Rhino Brep has a curved face.
+
+    Args:
+        brep: A Rhino Brep to test whether it has a curved face.
+    """
+    for b_face in brep.Faces:
+        if not b_face.IsPlanar(tolerance):
+            return True
+    return False
+
+
+def mesh_faces_to_face3d(mesh):
+    """Convert a curved Rhino mesh faces into planar ladybug_geometry Face3D.
+
+    Args:
+        mesh: A curved Rhino mesh.
+
+    Returns:
+        A list of ladybug Face3D objects derived from the input mesh faces.
+    """
+    faces = []
+    for m_face in mesh.Faces:
+        if m_face.IsQuad:
+            lb_face = Face3D(
+                tuple(_point3d(mesh.Vertices[i]) for i in
+                        (m_face.A, m_face.B, m_face.C, m_face.D)))
+            if lb_face.check_planar(tolerance, False):
+                faces.append(lb_face)
+            else:
+                lb_face_1 = Face3D(
+                    tuple(_point3d(mesh.Vertices[i]) for i in
+                            (m_face.A, m_face.B, m_face.C)))
+                lb_face_2 = Face3D(
+                    tuple(_point3d(mesh.Vertices[i]) for i in
+                            (m_face.C, m_face.D, m_face.A)))
+                faces.extend([lb_face_1, lb_face_2])
+        else:
+            lb_face = Face3D(
+                tuple(_point3d(mesh.Vertices[i]) for i in
+                        (m_face.A, m_face.B, m_face.C)))
+            faces.append(lb_face)
+    return faces
 
 
 def _point3d(point):

--- a/ladybug_rhino/togeometry.py
+++ b/ladybug_rhino/togeometry.py
@@ -103,7 +103,7 @@ def to_face3d(geo, meshing_parameters=None):
     """List of Ladybug Face3D objects from a Rhino Brep, Surface or Mesh.
 
     Args:
-        brep: A Rhino Brep, Surface ro Mesh that will be converted into a list
+        brep: A Rhino Brep, Surface or Mesh that will be converted into a list
             of Ladybug Face3D.
         meshing_parameters: Optional Rhino Meshing Parameters to describe how
             curved faces should be convereted into planar elements. If None,
@@ -139,7 +139,7 @@ def to_face3d(geo, meshing_parameters=None):
                     faces.append(
                         Face3D(boundary=all_verts[0], holes=all_verts[1:]))
             else:  # curved face must be meshed into planar Face3D objects
-                faces.extend(_planar.curved_geometry_faces(b_face, meshing_parameters))
+                faces.extend(_planar.curved_surface_faces(b_face, meshing_parameters))
     return faces
 
 
@@ -153,7 +153,10 @@ def to_polyface3d(geo, meshing_parameters=None):
             curved faces should be convereted into planar elements. If None,
             Rhino's Default Meshing Parameters will be used.
     """
-    return Polyface3D.from_faces(to_face3d(geo, meshing_parameters), tolerance)
+    mesh_par = meshing_parameters or rg.MeshingParameters.Default # default
+    if isinstance(geo, rg.Brep) and geo.IsSolid:  # ensure solids are always correct
+        return Polyface3D.from_faces(_planar.curved_solid_faces(geo, mesh_par), tolerance)
+    return Polyface3D.from_faces(to_face3d(geo, mesh_par), tolerance)
 
 
 def to_mesh3d(mesh, color_by_face=True):


### PR DESCRIPTION
This commit adds another method to the planarize module to planarize curved solids in a way that preserves their solidity.

This method gets used in the to_polyface translator and will be used to make a new honeybee-grasshooper-core planarization component.

This PR also includes a colorize module to produce colored points but it's not being used at the moment.