### PR TITLE
fix(to_polyface): Use older method for planarization

### DIFF
--- a/ladybug_rhino/config.py
+++ b/ladybug_rhino/config.py
@@ -19,7 +19,7 @@ def conversion_to_meters():
 
     Returns:
         A number for the conversion factor, which should be multiplied by all distance
-        units taken from Rhino geoemtry in order to convert them to meters.
+        units taken from Rhino geometry in order to convert them to meters.
     """
     try:  # Try to import units from the active Rhino document
         import scriptcontext

--- a/ladybug_rhino/fromobjects.py
+++ b/ladybug_rhino/fromobjects.py
@@ -49,11 +49,11 @@ def compass_objects(compass, z=0, custom_angles=None, projection=None, font='Ari
         compass: A Ladybug Compass object to be converted to Rhino geometry.
         z: A number for the Z-coordinate to be used in translation. (Default: 0)
         custom_angles: An array of numbers between 0 and 360 to be used to
-            generate custom anle labels around the compass.
+            generate custom angle labels around the compass.
         projection: Text for the name of the projection to use from the sky
             dome hemisphere to the 2D plane. If None, no altitude circles o
             labels will be drawn (Default: None). Choose from the following:
-                * Orthograhphic
+                * Orthographic
                 * Stereographic
         font: Optional text for the font to be used in creating the text.
             (Default: 'Arial')

--- a/ladybug_rhino/grasshopper.py
+++ b/ladybug_rhino/grasshopper.py
@@ -26,7 +26,7 @@ def give_warning(component, message):
 
 
 def give_remark(component, message):
-    """Give an remark message (giving a little grey baloon in the upper left).
+    """Give an remark message (giving a little grey ballon in the upper left).
 
     Args:
         component: The grasshopper component object, which can be accessed through
@@ -141,8 +141,8 @@ def flatten_data_tree(input):
 
         -   all_data -- All data in DataTree as a flattened list.
 
-        -   pattern -- A dictonary of patterns as namedtuple(path, index of last item
-            on this path, path Count). Pattern is useful to unflatten the list
+        -   pattern -- A dictionary of patterns as namedtuple(path, index of last item
+            on this path, path Count). Pattern is useful to un-flatten the list
             back to a DataTree.
     """
     Pattern = namedtuple('Pattern', 'path index count')
@@ -169,7 +169,7 @@ def unflatten_to_data_tree(all_data, pattern):
 
     Args:
         all_data: A flattened list of all data
-        pattern: A dictonary of patterns
+        pattern: A dictionary of patterns
             Pattern = namedtuple('Pattern', 'path index count')
 
     Returns:

--- a/ladybug_rhino/intersect.py
+++ b/ladybug_rhino/intersect.py
@@ -1,6 +1,6 @@
 """Functions to handle intersection of Rhino geometries.
 
-These represent goemetry computation methods  that are either not supported by
+These represent geometry computation methods  that are either not supported by
 ladybug_geometry or there are much more efficient versions of them in Rhino.
 """
 
@@ -142,7 +142,7 @@ def intersect_solid(solid, other_solid):
                     solid = new_brep
                     break
 
-        # detect whether any intercextions were found in this while loop iteration
+        # detect whether any intersections were found in this while loop iteration
         if solid.Faces.Count == num_faces_start:
             done = True  # no intersections were found in this iteration of the loop
 
@@ -153,7 +153,7 @@ def overlapping_bounding_boxes(bound_box1, bound_box2):
     """Check if two Rhino bounding boxes overlap within the tolerance.
 
     This is particularly useful as a check before performing computationally
-    intense processes between two bound_boxs like intersectiony. Checking the
+    intense processes between two bounding boxes like intersection. Checking the
     overlap of the bounding boxes is extremely quick given this method's use
     of the Separating Axis Theorem.
 

--- a/ladybug_rhino/planarize.py
+++ b/ladybug_rhino/planarize.py
@@ -1,4 +1,5 @@
 """Functions to convert curved Rhino geometries into planar ladybug ones."""
+from .config import tolerance
 
 try:
     from ladybug_geometry.geometry3d.pointvector import Point3D
@@ -11,7 +12,10 @@ try:
 except ImportError as e:
     raise ImportError(
         "Failed to import Rhino.\n{}".format(e))
-from .config import tolerance
+
+import sys
+if (sys.version_info > (3, 0)):  # python 3
+    xrange = range
 
 
 """____________INDIVIDUAL SURFACES TO PLANAR____________"""
@@ -28,7 +32,7 @@ def planar_face_curved_edge_vertices(b_face, count, meshing_parameters):
         b_face: A brep face with the curved edge.
         count: An integer for the index of the loop to extract.
         meshing_parameters: Rhino Meshing Parameters to describe how
-            curved edge should be convereted into planar elements.
+            curved edge should be converted into planar elements.
     
     Returns:
         A list of ladybug Point3D objects representing the input planar face.
@@ -65,7 +69,7 @@ def curved_surface_faces(b_face, meshing_parameters):
     Args:
         b_face: A curved brep face.
         meshing_parameters: Rhino Meshing Parameters to describe how
-            curved edge should be convereted into planar elements.
+            curved edge should be converted into planar elements.
     
     Returns:
         A list of ladybug Face3D objects that together approximate the input
@@ -90,7 +94,7 @@ def curved_solid_faces(brep, meshing_parameters):
     Args:
         brep: A curved solid brep.
         meshing_parameters: Rhino Meshing Parameters to describe how
-            curved edge should be convereted into planar elements.
+            curved edge should be converted into planar elements.
 
     Returns:
         A list of ladybug Face3D objects that together approximate the input brep.
@@ -114,7 +118,8 @@ def curved_solid_faces(brep, meshing_parameters):
                     Face3D(boundary=all_verts[0], holes=all_verts[1:]))
         else:
             faces.extend(mesh_faces_to_face3d(mesh))
-    return faces
+    # remove colinear vertices as the meshing process makes a lot of them
+    return [face.remove_colinear_vertices(tolerance) for face in faces]
 
 
 """________________EXTRA HELPER FUNCTIONS________________"""

--- a/ladybug_rhino/togeometry.py
+++ b/ladybug_rhino/togeometry.py
@@ -106,10 +106,10 @@ def to_face3d(geo, meshing_parameters=None):
         brep: A Rhino Brep, Surface or Mesh that will be converted into a list
             of Ladybug Face3D.
         meshing_parameters: Optional Rhino Meshing Parameters to describe how
-            curved faces should be convereted into planar elements. If None,
+            curved faces should be converted into planar elements. If None,
             Rhino's Default Meshing Parameters will be used.
     """
-    faces = []  # list of Face3Ds to be polulated and returned
+    faces = []  # list of Face3Ds to be populated and returned
     if isinstance(geo, rg.Mesh):  # convert each Mesh face to a Face3D
         pts = tuple(to_point3d(pt) for pt in geo.Vertices)
         for face in geo.Faces:
@@ -150,14 +150,11 @@ def to_polyface3d(geo, meshing_parameters=None):
         geo: A Rhino Brep, Surface ro Mesh that will be converted into a single
             Ladybug Polyface3D.
         meshing_parameters: Optional Rhino Meshing Parameters to describe how
-            curved faces should be convereted into planar elements. If None,
+            curved faces should be converted into planar elements. If None,
             Rhino's Default Meshing Parameters will be used.
     """
     mesh_par = meshing_parameters or rg.MeshingParameters.Default # default
-    if isinstance(geo, rg.Brep) and geo.IsSolid:  # ensure solids are always correct
-        return Polyface3D.from_faces(_planar.curved_solid_faces(geo, mesh_par), tolerance)
     return Polyface3D.from_faces(to_face3d(geo, mesh_par), tolerance)
-
 
 def to_mesh3d(mesh, color_by_face=True):
     """Ladybug Mesh3D from Rhino Mesh."""


### PR DESCRIPTION
It turns out that meshing each and every solid Brep to get vertices creates a lot of problems. It seems better to use our old method and, if people need to planarize curved geometry, they can use the dedicated planarization component.

I also fixed a bunch of typos across the library.