### PR TITLE
fix(geometry): Add extra check for duplicate vertices

### DIFF
--- a/ladybug_rhino/fromgeometry.py
+++ b/ladybug_rhino/fromgeometry.py
@@ -151,16 +151,26 @@ def from_polyface3d_to_wireframe(polyface):
 
 
 def from_face3d_to_solid(face, offset):
-    """Rhino Solid Brep from a ladybug Face3D and an offset."""
+    """Rhino Solid Brep from a ladybug Face3D and an offset from the base face.
+    
+    Args:
+        face: Ladybug geometry Face3D object.
+        offset: Number for the offset distance from the base face.
+    """
     srf_brep = from_face3d(face)
     return rg.Brep.CreateFromOffsetFace(
         srf_brep.Faces[0], offset, tolerance, False, True)
 
 
+def from_face3ds_to_joined_brep(faces):
+    """A list of joined Breps from an array of ladybug Face3D."""
+    return rg.Brep.JoinBreps([from_face3d(face) for face in faces], tolerance)
+
+
 def from_face3ds_to_colored_mesh(faces, color):
     """Colored Rhino mesh from an array of ladybug Face3D and ladybug Color.
 
-    This is used in workflows such as coloring Model geomtry with results.
+    This is used in workflows such as coloring Model geometry with results.
     """
     joined_mesh = rg.Mesh()
     for face in faces:

--- a/ladybug_rhino/planarize.py
+++ b/ladybug_rhino/planarize.py
@@ -93,14 +93,16 @@ def curved_solid_faces(brep, meshing_parameters):
 
     Args:
         brep: A curved solid brep.
-        meshing_parameters: Rhino Meshing Parameters to describe how
-            curved edge should be converted into planar elements.
+        meshing_parameters: Rhino Meshing Parameters to describe how curved surfaces
+            should be converted into planar elements. If None, Rhino's Default
+            Meshing Parameters will be used.
 
     Returns:
         A list of ladybug Face3D objects that together approximate the input brep.
     """
     # mesh the geometry as a solid
-    meshed_geo = rg.Mesh.CreateFromBrep(brep, meshing_parameters)
+    mesh_par = meshing_parameters or rg.MeshingParameters.Default  # default
+    meshed_geo = rg.Mesh.CreateFromBrep(brep, mesh_par)
 
     # evaluate each mesh face to see what larger brep face it is a part of
     faces = []


### PR DESCRIPTION
It seems that it's possible to have a Brep where the object doesn't have duplicate vertices but the loops of the Brep's faces have them.  So this commit adds an extra check to remove such duplicate vertices.

I am also updating the polyface translators to used the more robust meshing translation whenever the input Brep has a curved face since this should help preserve solidity in more cases of using the default components without the "Planarize Brep" component.

Lastly, I am changing some of the methods so that I can remove the RhinoCommon import statement in the "Planarize Brep" component.