### PR TITLE
fix(togeometry): Catch the case of zero-area mesh faces

### DIFF
--- a/ladybug_rhino/togeometry.py
+++ b/ladybug_rhino/togeometry.py
@@ -118,7 +118,9 @@ def to_face3d(geo, meshing_parameters=None):
                 all_verts = (pts[face[0]], pts[face[1]], pts[face[2]], pts[face[3]])
             else:
                 all_verts = (pts[face[0]], pts[face[1]], pts[face[2]])
-            faces.append(Face3D(all_verts))
+            lb_face = Face3D(all_verts)
+            if lb_face.area != 0:
+                faces.append(Face3D(all_verts))
     else:  # convert each Brep Face to a Face3D
         meshing_parameters = meshing_parameters or rg.MeshingParameters.Default  # default
         for b_face in geo.Faces:


### PR DESCRIPTION
While Rhino has robust checks that prevent most Breps from having 0 area, the same can't really be said for meshes. So I'm adding a zero-area for the mesh case just to be sure. It has a negligible effect on the run-time since we're already computing the area to ensure the vertices are counter-clockwise.