### PR TITLE
fix(pythonpath): Add packages for recipes

### DIFF
--- a/ladybug_rhino/pythonpath.py
+++ b/ladybug_rhino/pythonpath.py
@@ -14,7 +14,8 @@ PACKAGES = \
     ('ladybug_rhino', 'ladybug_geometry', 'ladybug_geometry_polyskel',
      'ladybug', 'ladybug_comfort', 'honeybee', 'honeybee_standards', 'honeybee_energy',
      'honeybee_radiance', 'honeybee_radiance_folder', 'honeybee_radiance_command',
-     'dragonfly', 'dragonfly_energy', 'dragonfly_radiance', 'dragonfly_uwg')
+     'dragonfly', 'dragonfly_energy', 'dragonfly_radiance', 'dragonfly_uwg',
+     'lbt_recipes', 'pollination_handlers')
 # Rhino versions that the plugins are compatible with
 RHINO_VERSIONS = ('6.0', '7.0')
 # UUID that McNeel uses to identify the IronPython plugin


### PR DESCRIPTION
This will ensure that, for the Mac installation, the recipe packages will get copied to and cleaned out of the Rhino scripts folder as expected.