### PR TITLE
fix(intersection.py): Replace the intersection if else statement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ tox.ini
 .eggs
 honeybee.log*
 *.code-workspace
+.vs

--- a/ladybug_rhino/intersect.py
+++ b/ladybug_rhino/intersect.py
@@ -154,7 +154,7 @@ def intersect_mesh_lines(mesh, start_points, end_points, max_dist=None, parallel
         for ept in end_points:
             lin = rg.Line(pt, ept)
             int_obj = rg.Intersect.Intersection.MeshLine(mesh, lin)
-            is_clear = 1 if len(int_obj) == 0 or int_obj[1] is None else 0
+            is_clear = 0 if int_obj else 1
             int_list.append(is_clear)
         int_matrix[i] = int_list
 
@@ -168,7 +168,7 @@ def intersect_mesh_lines(mesh, start_points, end_points, max_dist=None, parallel
                 int_list.append(0)
             else:
                 int_obj = rg.Intersect.Intersection.MeshLine(mesh, lin)
-                is_clear = 1 if len(int_obj) == 0 or int_obj[1] is None else 0
+                is_clear = 0 if int_obj else 1
                 int_list.append(is_clear)
         int_matrix[i] = int_list
 


### PR DESCRIPTION
Hi @chriswmackey 
we can try in this way. It gives you an` Empty Array `when the intersection fails because of the ironpython/python truth values.