### PR TITLE
fix(cli): Change set-python-search to use ladybug-tools-folder

### DIFF
--- a/ladybug_rhino/pythonpath.py
+++ b/ladybug_rhino/pythonpath.py
@@ -5,6 +5,7 @@ import xml.etree.ElementTree
 
 try:
     from ladybug.futil import nukedir, copy_file_tree
+    from ladybug.config import folders as lb_folders
 except ImportError as e:
     raise ImportError("Failed to import ladybug.\n{}".format(e))
 
@@ -28,8 +29,7 @@ def create_python_package_dir():
     This method works both on Windows and Mac. If the folder is not found, this
     method will create the folder.
     """
-    home_folder = os.getenv('HOME') or os.path.expanduser('~')
-    py_install = os.path.join(home_folder, 'ladybug_tools', 'python')
+    py_install = os.path.join(lb_folders.ladybug_tools_folder, 'python')
     py_path = os.path.join(py_install, 'Lib', 'site-packages') if os.name == 'nt' \
         else os.path.join(py_install, 'lib', 'python3.7', 'site-packages')
     if not os.path.isdir(py_path):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ladybug-core>=0.25.0
+ladybug-core>=0.39.0


### PR DESCRIPTION
Instead of assuming that the ladybug_tools folder is always in the same location, this will take the ladybug_tools_folder from the ladybug configuration. So, if someone has changed the install location of the ladybug_tools_folder, the set-python-search command will be able to compensate.