### PR TITLE
fix(fromgeometry): Implement more robust way to get colored meshes

### DIFF
--- a/ladybug_rhino/fromgeometry.py
+++ b/ladybug_rhino/fromgeometry.py
@@ -243,8 +243,7 @@ def from_face3ds_to_colored_mesh(faces, color):
     joined_mesh = rg.Mesh()
     for face in faces:
         try:
-            joined_mesh.Append(rg.Mesh.CreateFromBrep(
-                from_face3d(face), rg.MeshingParameters.Default)[0])
+            joined_mesh.Append(from_mesh3d(face.triangulated_mesh3d))
         except Exception:
             pass  # failed to create a Rhino Mesh from the Face3D
     joined_mesh.VertexColors.CreateMonotoneMesh(color_to_color(color))


### PR DESCRIPTION
If we use ladybug_geometry's built-in triangulation methods to get the mesh, this will allow us to preview geometries with holes better.