### PR TITLE
fix(userobject): Handle the case that access to Program Files is denied

### DIFF
--- a/ladybug_rhino/versioning/userobject.py
+++ b/ladybug_rhino/versioning/userobject.py
@@ -89,7 +89,10 @@ def create_userobject(component, move=True):
             os.mkdir(ufd)
         elif os.path.isfile(ufp):
             # remove current userobject
-            os.remove(ufp)
+            try:
+                os.remove(ufp)
+            except Exception:
+                pass  # access is denied to the user object location
         uo.Path = ufp
 
     uo.SaveToFile()


### PR DESCRIPTION
This is needed now that we are storing the user objects in Program Files.