### PR TITLE
fix(visset): Move Bake-able VisualizationSet to its own module

### DIFF
--- a/ladybug_rhino/bakeobjects.py
+++ b/ladybug_rhino/bakeobjects.py
@@ -48,12 +48,6 @@ try:
 except ImportError as e:
     raise ImportError("Failed to import Rhino document attributes.\n{}".format(e))
 
-try:
-    import Grasshopper as gh
-except ImportError:
-    print('Failed to import Grasshopper.Grasshopper Baking disabled.')
-    gh = None
-
 BAKE_MAPPER = {
     Vector2D: bake_vector2d,
     Point2D: bake_point2d,
@@ -286,31 +280,3 @@ def bake_visualization_set(vis_set, bake_3d_legend=False):
         else:  # translate it as ContextGeometry
             obj_ids.extend(bake_context(geo, vis_set.display_name))
     return obj_ids
-
-
-class VisSetGoo(gh.Kernel.IGH_BakeAwareData):
-    """A Bake-able version of the VisualizationSet for Grasshopper.
-
-    Args:
-        visualization_set: A Ladybug Display VisualizationSet object to be bake-able
-            in the Rhino scene.
-    """
-
-    def __init__(self, visualization_set):
-        self.vis_set = visualization_set
-
-    def BakeGeometry(self, doc, att, id):
-        try:
-            if self.vis_set is not None:
-                guids = bake_visualization_set(self.vis_set, True)
-                return True, guids
-        except Exception as e:
-            System.Windows.Forms.MessageBox.Show(str(e), 'script error')
-            return False, System.Guid.Empty
-
-    def ToString(self):
-        """Overwrite .NET ToString method."""
-        return self.__repr__()
-
-    def __repr__(self):
-        return str(self.vis_set)

--- a/ladybug_rhino/visset.py
+++ b/ladybug_rhino/visset.py
@@ -1,0 +1,41 @@
+"""Class to for a bake-able version of ladybug-display VisualizationSet."""
+from .bakeobjects import bake_visualization_set
+
+try:
+    import System
+except ImportError as e:
+    raise ImportError("Failed to import Windows/.NET libraries\n{}".format(e))
+
+try:
+    import Grasshopper as gh
+except ImportError:
+    print('Failed to import Grasshopper.Grasshopper Baking disabled.')
+    gh = None
+
+
+class VisSetGoo(gh.Kernel.IGH_BakeAwareData):
+    """A Bake-able version of the VisualizationSet for Grasshopper.
+
+    Args:
+        visualization_set: A Ladybug Display VisualizationSet object to be bake-able
+            in the Rhino scene.
+    """
+
+    def __init__(self, visualization_set):
+        self.vis_set = visualization_set
+
+    def BakeGeometry(self, doc, att, id):
+        try:
+            if self.vis_set is not None:
+                guids = bake_visualization_set(self.vis_set, True)
+                return True, guids
+        except Exception as e:
+            System.Windows.Forms.MessageBox.Show(str(e), 'script error')
+            return False, System.Guid.Empty
+
+    def ToString(self):
+        """Overwrite .NET ToString method."""
+        return self.__repr__()
+
+    def __repr__(self):
+        return str(self.vis_set)


### PR DESCRIPTION
This should prevent possible errors when Grasshopper is not yet loaded.