### PR TITLE
fix(add layer): use -1 as the default value for notFoundReturnValue

### DIFF
--- a/ladybug_rhino/bakegeometry.py
+++ b/ladybug_rhino/bakegeometry.py
@@ -235,11 +235,11 @@ def _get_attributes(layer_name=None, attributes=None):
 def _get_layer(layer_name):
     """Get a layer index from the Rhino document from the layer name."""
     layer_table = doc.Layers  # layer table
-    layer_index = layer_table.FindByFullPath(layer_name, True)
+    layer_index = layer_table.FindByFullPath(layer_name, -1)
     if layer_index < 0:
         all_layers = layer_name.split('::')
         parent_name = all_layers[0]
-        layer_index = layer_table.FindByFullPath(parent_name, True)
+        layer_index = layer_table.FindByFullPath(parent_name, -1)
         if layer_index < 0:
             parent_layer = docobj.Layer()
             parent_layer.Name = parent_name
@@ -247,7 +247,7 @@ def _get_layer(layer_name):
         for lay in all_layers[1:]:
             parent_name = '{}::{}'.format(parent_name, lay)
             parent_index = layer_index
-            layer_index = layer_table.FindByFullPath(parent_name, True)
+            layer_index = layer_table.FindByFullPath(parent_name, -1)
             if layer_index < 0:
                 parent_layer = docobj.Layer()
                 parent_layer.Name = lay


### PR DESCRIPTION
The RhinoComman has been updated to take an integer for the second value instead of a Boolean. See here: https://developer.rhino3d.com/api/rhinocommon/rhino.docobjects.tables.layertable/findbyfullpath