### PR TITLE
fix: remove cached version of the active doc

### DIFF
--- a/ladybug_rhino/bakedisplay.py
+++ b/ladybug_rhino/bakedisplay.py
@@ -13,7 +13,6 @@ try:
     import Rhino.Display as rd
     import Rhino.DocObjects as docobj
     import Rhino.RhinoDoc as rhdoc
-    doc = rhdoc.ActiveDoc
 except ImportError as e:
     raise ImportError("Failed to import Rhino document attributes.\n{}".format(e))
 
@@ -206,6 +205,7 @@ def bake_display_text3d(display_text, layer_name=None, attributes=None):
             text. If None, text will be added to the current layer.
         attributes: Optional Rhino attributes for adding to the Rhino scene.
     """
+    doc = rhdoc.ActiveDoc
     d_txt = display_text.text
     nl_count = len(d_txt.split('\n')) - 1
     if nl_count > 1 and display_text.vertical_alignment == 'Bottom':

--- a/ladybug_rhino/bakegeometry.py
+++ b/ladybug_rhino/bakegeometry.py
@@ -11,9 +11,9 @@ except ImportError as e:
 
 try:
     import Rhino.Geometry as rg
+    from Rhino.RhinoMath import UnsetIntIndex
     import Rhino.DocObjects as docobj
     import Rhino.RhinoDoc as rhdoc
-    doc = rhdoc.ActiveDoc
 except ImportError as e:
     raise ImportError("Failed to import Rhino document attributes.\n{}".format(e))
 
@@ -22,6 +22,7 @@ except ImportError as e:
 
 def bake_vector2d(vector, z=0, layer_name=None, attributes=None):
     """Add ladybug Ray2D to the Rhino scene as a Line with an Arrowhead."""
+    doc = rhdoc.ActiveDoc
     seg = (rg.Point3d(0, 0, z), rg.Point3d(vector.x, vector.y, z))
     attrib = _get_attributes(layer_name, attributes)
     attrib.ObjectDecoration = docobj.ObjectDecoration.EndArrowhead
@@ -30,12 +31,14 @@ def bake_vector2d(vector, z=0, layer_name=None, attributes=None):
 
 def bake_point2d(point, z=0, layer_name=None, attributes=None):
     """Add ladybug Point2D to the Rhino scene as a Point."""
+    doc = rhdoc.ActiveDoc
     pt = from_point2d(point, z)
     return doc.Objects.AddPoint(pt, _get_attributes(layer_name, attributes))
 
 
 def bake_ray2d(ray, z=0, layer_name=None, attributes=None):
     """Add ladybug Ray2D to the Rhino scene as a Line with an Arrowhead."""
+    doc = rhdoc.ActiveDoc
     seg = (from_point2d(ray.p, z), from_point2d(ray.p + ray.v, z))
     attrib = _get_attributes(layer_name, attributes)
     attrib.ObjectDecoration = docobj.ObjectDecoration.EndArrowhead
@@ -44,12 +47,14 @@ def bake_ray2d(ray, z=0, layer_name=None, attributes=None):
 
 def bake_linesegment2d(line, z=0, layer_name=None, attributes=None):
     """Add ladybug LineSegment2D to the Rhino scene as a Line."""
+    doc = rhdoc.ActiveDoc
     seg = (from_point2d(line.p1, z), from_point2d(line.p2, z))
     return doc.Objects.AddLine(seg[0], seg[1], _get_attributes(layer_name, attributes))
 
 
 def bake_polygon2d(polygon, z=0, layer_name=None, attributes=None):
     """Add ladybug Polygon2D to the Rhino scene as a Polyline."""
+    doc = rhdoc.ActiveDoc
     pgon = [from_point2d(pt, z) for pt in polygon.vertices] + \
         [from_point2d(polygon[0], z)]
     return doc.Objects.AddPolyline(pgon, _get_attributes(layer_name, attributes))
@@ -57,6 +62,7 @@ def bake_polygon2d(polygon, z=0, layer_name=None, attributes=None):
 
 def bake_arc2d(arc, z=0, layer_name=None, attributes=None):
     """Add ladybug Arc2D to the Rhino scene as an Arc or a Circle."""
+    doc = rhdoc.ActiveDoc
     rh_arc = from_arc2d(arc, z)
     if arc.is_circle:
         return doc.Objects.AddCircle(rh_arc, _get_attributes(layer_name, attributes))
@@ -66,12 +72,14 @@ def bake_arc2d(arc, z=0, layer_name=None, attributes=None):
 
 def bake_polyline2d(polyline, z=0, layer_name=None, attributes=None):
     """Add ladybug Polyline2D to the Rhino scene as a Curve."""
+    doc = rhdoc.ActiveDoc
     rh_crv = from_polyline2d(polyline, z)
     return doc.Objects.AddCurve(rh_crv, _get_attributes(layer_name, attributes))
 
 
 def bake_mesh2d(mesh, z=0, layer_name=None, attributes=None):
     """Add ladybug Mesh2D to the Rhino scene as a Mesh."""
+    doc = rhdoc.ActiveDoc
     _mesh = from_mesh2d(mesh, z)
     return doc.Objects.AddMesh(_mesh, _get_attributes(layer_name, attributes))
 
@@ -81,6 +89,7 @@ def bake_mesh2d(mesh, z=0, layer_name=None, attributes=None):
 
 def bake_vector3d(vector, layer_name=None, attributes=None):
     """Add ladybug Ray2D to the Rhino scene as a Line with an Arrowhead."""
+    doc = rhdoc.ActiveDoc
     seg = (rg.Point3d(0, 0, 0), rg.Point3d(vector.x, vector.y, vector.z))
     attrib = _get_attributes(layer_name, attributes)
     attrib.ObjectDecoration = docobj.ObjectDecoration.EndArrowhead
@@ -89,12 +98,14 @@ def bake_vector3d(vector, layer_name=None, attributes=None):
 
 def bake_point3d(point, layer_name=None, attributes=None):
     """Add ladybug Point3D to the Rhino scene as a Point."""
+    doc = rhdoc.ActiveDoc
     pt = from_point3d(point)
     return doc.Objects.AddPoint(pt, _get_attributes(layer_name, attributes))
 
 
 def bake_ray3d(ray, layer_name=None, attributes=None):
     """Add ladybug Ray2D to the Rhino scene as a Line with an Arrowhead."""
+    doc = rhdoc.ActiveDoc
     seg = (from_point3d(ray.p), from_point3d(ray.p + ray.v))
     attrib = _get_attributes(layer_name, attributes)
     attrib.ObjectDecoration = docobj.ObjectDecoration.EndArrowhead
@@ -103,6 +114,7 @@ def bake_ray3d(ray, layer_name=None, attributes=None):
 
 def bake_plane(plane, layer_name=None, attributes=None):
     """Add ladybug Plane to the Rhino scene as a Rectangle."""
+    doc = rhdoc.ActiveDoc
     rh_pln = from_plane(plane)
     r = 10  # default radius for a plane object in rhino model units
     interval = rg.Interval(-r / 2, r / 2)
@@ -112,12 +124,14 @@ def bake_plane(plane, layer_name=None, attributes=None):
 
 def bake_linesegment3d(line, layer_name=None, attributes=None):
     """Add ladybug LineSegment3D to the Rhino scene as a Line."""
+    doc = rhdoc.ActiveDoc
     seg = (from_point3d(line.p1), from_point3d(line.p2))
     return doc.Objects.AddLine(seg[0], seg[1], _get_attributes(layer_name, attributes))
 
 
 def bake_arc3d(arc, layer_name=None, attributes=None):
     """Add ladybug Arc3D to the Rhino scene as an Arc or Circle."""
+    doc = rhdoc.ActiveDoc
     rh_arc = from_arc3d(arc)
     if arc.is_circle:
         return doc.Objects.AddCircle(rh_arc, _get_attributes(layer_name, attributes))
@@ -127,42 +141,49 @@ def bake_arc3d(arc, layer_name=None, attributes=None):
 
 def bake_polyline3d(polyline, layer_name=None, attributes=None):
     """Add ladybug Polyline3D to the Rhino scene as a Curve."""
+    doc = rhdoc.ActiveDoc
     rh_crv = from_polyline3d(polyline)
     return doc.Objects.AddCurve(rh_crv, _get_attributes(layer_name, attributes))
 
 
 def bake_mesh3d(mesh, layer_name=None, attributes=None):
     """Add ladybug Mesh3D to the Rhino scene as a Mesh."""
+    doc = rhdoc.ActiveDoc
     _mesh = from_mesh3d(mesh)
     return doc.Objects.AddMesh(_mesh, _get_attributes(layer_name, attributes))
 
 
 def bake_face3d(face, layer_name=None, attributes=None):
     """Add ladybug Face3D to the Rhino scene as a Brep."""
+    doc = rhdoc.ActiveDoc
     _face = from_face3d(face)
     return doc.Objects.AddBrep(_face, _get_attributes(layer_name, attributes))
 
 
 def bake_polyface3d(polyface, layer_name=None, attributes=None):
     """Add ladybug Polyface3D to the Rhino scene as a Brep."""
+    doc = rhdoc.ActiveDoc
     rh_polyface = from_polyface3d(polyface)
     return doc.Objects.AddBrep(rh_polyface, _get_attributes(layer_name, attributes))
 
 
 def bake_sphere(sphere, layer_name=None, attributes=None):
     """Add ladybug Sphere to the Rhino scene as a Brep."""
+    doc = rhdoc.ActiveDoc
     rh_sphere = from_sphere(sphere).ToBrep()
     return doc.Objects.AddBrep(rh_sphere, _get_attributes(layer_name, attributes))
 
 
 def bake_cone(cone, layer_name=None, attributes=None):
     """Add ladybug Cone to the Rhino scene as a Brep."""
+    doc = rhdoc.ActiveDoc
     rh_cone = from_cone(cone).ToBrep()
     return doc.Objects.AddBrep(rh_cone, _get_attributes(layer_name, attributes))
 
 
 def bake_cylinder(cylinder, layer_name=None, attributes=None):
     """Add ladybug Cylinder to the Rhino scene as a Brep."""
+    doc = rhdoc.ActiveDoc
     rh_cylinder = from_cylinder(cylinder).ToBrep()
     return doc.Objects.AddBrep(rh_cylinder, _get_attributes(layer_name, attributes))
 
@@ -172,6 +193,7 @@ def bake_cylinder(cylinder, layer_name=None, attributes=None):
 
 def bake_mesh3d_as_hatch(mesh, layer_name=None, attributes=None):
     """Add ladybug Mesh3D to the Rhino scene as a colored hatch."""
+    doc = rhdoc.ActiveDoc
     # get a list of colors that align with the mesh faces
     if mesh.colors is not None:
         if mesh.is_color_by_face:
@@ -222,6 +244,7 @@ def bake_mesh3d_as_hatch(mesh, layer_name=None, attributes=None):
 
 def _get_attributes(layer_name=None, attributes=None):
     """Get Rhino object attributes."""
+    doc = rhdoc.ActiveDoc
     attributes = doc.CreateDefaultAttributes() if attributes is None else attributes
     if layer_name is None:
         return attributes
@@ -234,23 +257,25 @@ def _get_attributes(layer_name=None, attributes=None):
 
 def _get_layer(layer_name):
     """Get a layer index from the Rhino document from the layer name."""
+    doc = rhdoc.ActiveDoc
     layer_table = doc.Layers  # layer table
-    layer_index = layer_table.FindByFullPath(layer_name, True)
-    if layer_index < 0:
+    layer_index = layer_table.FindByFullPath(layer_name, UnsetIntIndex)
+    if layer_index == UnsetIntIndex:
         all_layers = layer_name.split('::')
         parent_name = all_layers[0]
-        layer_index = layer_table.FindByFullPath(parent_name, True)
-        if layer_index < 0:
+        layer_index = layer_table.FindByFullPath(parent_name, UnsetIntIndex)
+        if layer_index == UnsetIntIndex:
             parent_layer = docobj.Layer()
             parent_layer.Name = parent_name
             layer_index = layer_table.Add(parent_layer)
         for lay in all_layers[1:]:
             parent_name = '{}::{}'.format(parent_name, lay)
             parent_index = layer_index
-            layer_index = layer_table.FindByFullPath(parent_name, True)
-            if layer_index < 0:
+            layer_index = layer_table.FindByFullPath(parent_name, UnsetIntIndex)
+            if layer_index == UnsetIntIndex:
                 parent_layer = docobj.Layer()
                 parent_layer.Name = lay
                 parent_layer.ParentLayerId = layer_table[parent_index].Id
                 layer_index = layer_table.Add(parent_layer)
+
     return layer_index

--- a/ladybug_rhino/bakeobjects.py
+++ b/ladybug_rhino/bakeobjects.py
@@ -44,7 +44,6 @@ except ImportError as e:
 try:
     import Rhino.DocObjects as docobj
     import Rhino.RhinoDoc as rhdoc
-    doc = rhdoc.ActiveDoc
 except ImportError as e:
     raise ImportError("Failed to import Rhino document attributes.\n{}".format(e))
 
@@ -161,6 +160,7 @@ def bake_analysis(analysis, layer_name=None, bake_3d_legend=False,
     Returns:
         A list of IDs that point to the objects in the Rhino scene.
     """
+    doc = rhdoc.ActiveDoc
     # get attributes corresponding to the layer
     layer_name = analysis.display_name if layer_name is None else \
         '{}::{}'.format(layer_name, analysis.display_name)
@@ -235,6 +235,7 @@ def bake_context(context, layer_name=None):
     Returns:
         A list of IDs that point to the objects in the Rhino scene.
     """
+    doc = rhdoc.ActiveDoc
     # get attributes corresponding to the layer
     layer_name = context.display_name if layer_name is None else \
         '{}::{}'.format(layer_name, context.display_name)

--- a/ladybug_rhino/light.py
+++ b/ladybug_rhino/light.py
@@ -9,7 +9,6 @@ except ImportError as e:  # No .NET; We are really screwed
 try:
     import Rhino.Render.Sun as sun
     import Rhino.RhinoDoc as rhdoc
-    doc = rhdoc.ActiveDoc
 except ImportError as e:
     raise ImportError("Failed to import Rhino document attributes.\n{}".format(e))
 
@@ -31,6 +30,7 @@ def set_sun(location, hoy, north=0):
     Returns:
         The Rhino sun object.
     """
+    doc = rhdoc.ActiveDoc
     # process the hoy into a .NET date/time
     lb_dt = DateTime.from_hoy(hoy)
     rh_dt = System.DateTime(
@@ -49,4 +49,5 @@ def set_sun(location, hoy, north=0):
 
 def disable_sun():
     """Disable the sun in the Rhino scene so it does not interfere with other lights."""
+    doc = rhdoc.ActiveDoc
     doc.Lights.Sun.Enabled = False


### PR DESCRIPTION
We currently get the active doc once when we import the libraries. This causes issues for baking the visualization sets from the panel. Here is how you can recreate the issue.

1. Open Rhino and Pollination Panel.
2. Bake the visualization set for a study.
3. Open a new file.
4. Try to bake the visualization set in the new file.

You will get an error: Could not find Layer with ID 00000000-0000-0000-0000-000000000000

This is happening because when the code tries to look up the layers and create them the `doc` variable is still referring to the previous Rhino document which had the layer and is now closed. Since the older document already had this layer, Rhino doesn't create the new layer and then when it tries to bake the geometry to that layer it sees that the layer doesn't exist and throws an error.

This commit fixes this issue by accessing the active doc from inside every function.

It also updates the call for `FindByFullPath` to use the latest version of RhinoCommon and uses `UnserIntIndex` which is what `rhinoscriptsyntax` library is using.