### PR TITLE
fix(text): Finally fix the scaling issue when baking text

### DIFF
--- a/ladybug_rhino/bakedisplay.py
+++ b/ladybug_rhino/bakedisplay.py
@@ -205,6 +205,7 @@ def bake_display_text3d(display_text, layer_name=None, attributes=None):
             text. If None, text will be added to the current layer.
         attributes: Optional Rhino attributes for adding to the Rhino scene.
     """
+    # extract properties from the text
     doc = rhdoc.ActiveDoc
     d_txt = display_text.text
     nl_count = len(d_txt.split('\n')) - 1
@@ -213,14 +214,18 @@ def bake_display_text3d(display_text, layer_name=None, attributes=None):
         t_pln = display_text.plane.move(m_vec)
     else:
         t_pln = display_text.plane
-    txt_h = display_text.height * 0.666
+    txt_h = display_text.height
+    # create the Rhino Display Text object
     txt = rd.Text3d(d_txt, from_plane(t_pln), txt_h)
     txt.FontFace = display_text.font
     txt.HorizontalAlignment = TEXT_HORIZ[display_text.horizontal_alignment]
     txt.VerticalAlignment = TEXT_VERT[display_text.vertical_alignment]
     attrib = _get_attributes(layer_name, attributes)
     attrib.ObjectColor = color_to_color(display_text.color)
-    return doc.Objects.AddText(txt, attrib)
+    # add the text to the document and return the GUID
+    doc.ModelSpaceAnnotationScalingEnabled = False  # disable model scale
+    txt_guid = doc.Objects.AddText(txt, attrib)
+    return txt_guid
 
 
 """________________EXTRA HELPER FUNCTIONS________________"""

--- a/ladybug_rhino/text.py
+++ b/ladybug_rhino/text.py
@@ -147,9 +147,10 @@ class TextGoo(gh.Kernel.Types.GH_GeometricGoo[rh.Display.Text3d],
             new_plane = rh.Geometry.Plane(self.m_value.TextPlane)
             new_plane.Translate(m_vec)
             self.m_value.TextPlane = new_plane
-        self.m_value.Height = self.m_value.Height * (2 / 3)
+        self.m_value.Height = self.m_value.Height
+        doc.ModelSpaceAnnotationScalingEnabled = False  # disable model scale
         id = doc.Objects.AddText(self.m_value, att)
-        self.m_value.Height = self.m_value.Height * (3 / 2)
+        self.m_value.Height = self.m_value.Height
         if original_plane is not None:
             self.m_value.TextPlane = original_plane
         return True, id


### PR DESCRIPTION
It seems that the whole reason why I needed to add this mysterious factor in all of the text baking operations is because Rhino has this really annoying factor that scales all text in Model space, which was really hard to figure out. Now, I just disable it whenever we bake text and this always bakes the text correctly.