### PR TITLE
fix(Rhino8): fix dll reference issue in Rhino 8 .NetCore

### DIFF
--- a/ladybug_rhino/command.py
+++ b/ladybug_rhino/command.py
@@ -61,9 +61,9 @@ def import_pollination_core():
         if dll_dir is None:
             return None
         pol_dll = os.path.join(dll_dir, 'Pollination.Core.dll')
-        clr.AddReferenceToFileAndPath(pol_dll)
         if pol_dll not in sys.path:
             sys.path.append(pol_dll)
+        clr.AddReference("Pollination.Core")
         import Core
     return Core
 
@@ -78,9 +78,9 @@ def import_ladybug_display_schema():
         if dll_dir is None:
             return None
         pol_dll = os.path.join(dll_dir, 'LadybugDisplaySchema.dll')
-        clr.AddReferenceToFileAndPath(pol_dll)
         if pol_dll not in sys.path:
             sys.path.append(pol_dll)
+        clr.AddReference("LadybugDisplaySchema")
         import LadybugDisplaySchema
     return LadybugDisplaySchema
 
@@ -95,9 +95,9 @@ def import_honeybee_ui():
         if dll_dir is None:
             return None
         pol_dll = os.path.join(dll_dir, 'Honeybee.UI.Rhino.dll')
-        clr.AddReferenceToFileAndPath(pol_dll)
         if pol_dll not in sys.path:
             sys.path.append(pol_dll)
+        clr.AddReference("Honeybee.UI.Rhino")
         import Honeybee
     return Honeybee
 


### PR DESCRIPTION
Hi @chriswmackey, this pr fixes https://discourse.pollination.solutions/t/rhino-8-addtodoc-not-working-on-environmental-analysis-toolbar/3672/14